### PR TITLE
Replace get_current_theme() with wp_get_theme()

### DIFF
--- a/just-variables.theme.php
+++ b/just-variables.theme.php
@@ -41,7 +41,7 @@ function jv_theme_vars_admin_page(){
 	?>
 	<div class="wrap">
 		<?php screen_icon(); ?>
-		<h2><?php printf( __( '%s Theme Variables', JV_TEXTDOMAIN ), get_current_theme() ); ?></h2>
+		<h2><?php printf( __( '%s Theme Variables', JV_TEXTDOMAIN ), wp_get_theme() ); ?></h2>
 		<?php settings_errors(); ?>
 
 		<form method="post" action="options.php">


### PR DESCRIPTION
The function `get_current_theme()` has been deprecated since version 3.4. Replaced with `wp_get_theme()`.